### PR TITLE
Change `ENTRYPOINT` to `CMD` for a debug tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-ENTRYPOINT ["sleep", "infinity"]
+CMD ["/bin/sleep", "infinity"]
 
 
 ### nettools container image
@@ -46,7 +46,7 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-ENTRYPOINT ["sleep", "infinity"]
+CMD ["/bin/sleep", "infinity"]
 
 
 ### kubectl container image
@@ -59,4 +59,4 @@ RUN apt update && apt install -y gnupg2  && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-ENTRYPOINT ["sleep", "infinity"]
+CMD ["/bin/sleep", "infinity"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-CMD ["/bin/sleep", "infinity"]
+CMD ["sleep", "infinity"]
 
 
 ### nettools container image
@@ -46,7 +46,7 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-CMD ["/bin/sleep", "infinity"]
+CMD ["sleep", "infinity"]
 
 
 ### kubectl container image
@@ -59,4 +59,4 @@ RUN apt update && apt install -y gnupg2  && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-CMD ["/bin/sleep", "infinity"]
+CMD ["sleep", "infinity"]

--- a/README.md
+++ b/README.md
@@ -63,21 +63,12 @@ All containers are available for the following arch:
 ## usage docker
 
 ```bash
-docker run --rm -d --name multitool ghcr.io/dergeberl/multitool:latest
-docker exec -it multitool /bin/bash
-```
-
-```bash
-docker stop multitool
+docker run --rm -it --name multitool ghcr.io/dergeberl/multitool:latest /bin/bash
 ```
 
 ## usage kubernetes
 
 ```bash
-kubectl run --image ghcr.io/dergeberl/multitool:latest multitool
-kubectl exec multitool -it -- /bin/bash
+kubectl run -i --tty --image ghcr.io/dergeberl/multitool:latest multitool -- /bin/bash
 ```
 
-```bash
-kubectl delete pod multitool
-```


### PR DESCRIPTION
/kind enhancement

## Why this change?
I think it's more convenient to be able to overwrite the `ENTRYPOINT` of a debug tool instead of forcing it.
Now it will be able to have the same functionality as before, but with a single command instead of multiple.

Now it's also possible to exec one-shoot commands:
```bash
docker run --rm -it --name multitool multitool curl stackit.de
```

## What has changed
- Changed in `Dockerfile`: `ENTRYPOINT` to `CMD`
- Updated `Readme.md`
